### PR TITLE
fix typo in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,6 +19,6 @@ when HTML5 has perfectly good semantics for that:
 
 ::
 
-  <section id="my-section-name">..</div>
+  <section id="my-section-name">..</section>
 
 as a basic example.


### PR DESCRIPTION
Shouldn't the `<section>` be closed by a `</section>`?
